### PR TITLE
Update MathSoc Exam Bank

### DIFF
--- a/src/links.yml
+++ b/src/links.yml
@@ -36,7 +36,7 @@ sections:
         target: https://marmoset.student.cs.uwaterloo.ca/
         description: Marmoset
       - name: /mathexams
-        target: http://mathsoc.uwaterloo.ca/exambank
+        target: https://mathsoc.uwaterloo.ca/university/exambank
         description: MathSoc Exam Bank
 
   - id: eng


### PR DESCRIPTION
The old link 404's, and going to `Exam Bank` on the MathSoc homepage now takes you to https://mathsoc.uwaterloo.ca/university/exambank.