### PR TITLE
Replace WatIAM white pages with Campus People Directory

### DIFF
--- a/src/links.yml
+++ b/src/links.yml
@@ -19,9 +19,9 @@ sections:
       - name: /owa
         target: https://outlook.office365.com/mail/inbox
         description: Outlook Web Access
-      - name: /wp
-        target: https://idm.uwaterloo.ca/search/authen/
-        description: WatIAM white pages
+      - name: /dir
+        target: https://iamtools.uwaterloo.ca/directory
+        description: Campus People Directory
       - name: /card
         target: https://watcard.uwaterloo.ca/OneWeb/Account/LogOn
         description: Manage my WatCard


### PR DESCRIPTION
WatIAM White Pages have been replaced by the [Campus People Directory](https://iamtools.uwaterloo.ca/directory).

This PR replaces the white pages endpoint `/wp` with `/dir` that points to `https://iamtools.uwaterloo.ca/directory`.

The endpoint name is tentative; alternatives welcome. 

Please review. Thanks.